### PR TITLE
Add multi-page room interface with playlist syncing

### DIFF
--- a/public/create.html
+++ b/public/create.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Create Room - SyncIt</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body class="create">
+  <div class="center">
+    <h1>New Room</h1>
+    <p>Your room code:</p>
+    <div id="code" class="room-code"></div>
+    <button id="enter" class="btn">Enter Room</button>
+  </div>
+  <script>
+    const code = Math.random().toString(36).slice(2,8).toUpperCase();
+    document.getElementById('code').textContent = code;
+    document.getElementById('enter').onclick = () => {
+      location.href = `room.html?roomId=${code}&host=1`;
+    };
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -2,82 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Real-time Multi-Speaker Room</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SyncIt</title>
   <link rel="stylesheet" href="./styles.css" />
 </head>
-<body>
-  <div class="container">
-    <h1>Real-time Music Room</h1>
-
-    <section class="room">
-      <input id="roomId" placeholder="Room ID (e.g. alpha123)" />
-      <input id="pin" placeholder="Optional PIN" />
-      <button id="createBtn">Create as Host</button>
-      <button id="joinBtn">Join Room</button>
-      <span id="me"></span>
-    </section>
-
-    <section class="host-panel hidden" id="hostPanel">
-      <h2>Host Controls</h2>
-      <div class="row">
-        <input type="file" id="fileInput" accept="audio/*" />
-        <button id="playBtn">Play</button>
-        <button id="pauseBtn">Pause</button>
-        <button id="stopBtn">Stop</button>
-      </div>
-      <div class="row">
-        <input type="range" id="seek" min="0" max="100" value="0" />
-        <span id="curTime">0:00</span> / <span id="dur">0:00</span>
-      </div>
-      <div class="row">
-        <label>Volume</label>
-        <input type="range" id="volume" min="0" max="1" step="0.01" value="1" />
-        <button id="muteBtn">Mute/Unmute</button>
-      </div>
-      <div class="row">
-        <label>Transfer host to</label>
-        <select id="transferSelect"></select>
-        <button id="transferBtn">Transfer</button>
-      </div>
-      <div class="row">
-        <label>Kick</label>
-        <select id="kickSelect"></select>
-        <button id="kickBtn">Kick</button>
-      </div>
-      <audio id="audio" crossorigin="anonymous" controls class="hidden"></audio>
-    </section>
-
-    <section class="status">
-      <h2>Room Status</h2>
-      <div>Room: <span id="roomLabel">—</span></div>
-      <div>Host: <span id="hostLabel">—</span></div>
-      <div>Clients: <span id="clients"></span></div>
-      <div>RTT: <span id="rtt">—</span> ms</div>
-    </section>
-
-    <section class="chat">
-      <h2>Chat</h2>
-      <div id="chatBox" class="chat-box"></div>
-      <div class="row">
-        <input id="chatInput" placeholder="Type a message..." />
-        <button id="chatSend">Send</button>
-      </div>
-    </section>
-
-    <section class="listener">
-      <h2>Listener</h2>
-      <div>
-        <audio id="remoteAudio" autoplay playsinline></audio>
-      </div>
-      <div class="row">
-        <label>Local volume</label>
-        <input type="range" id="localVol" min="0" max="1" step="0.01" value="1" />
-        <button id="localMute">Mute/Unmute</button>
-      </div>
-    </section>
+<body class="landing">
+  <div class="center">
+    <h1>SyncIt</h1>
+    <p class="tagline">Real-time synced music rooms</p>
+    <div class="actions">
+      <a class="btn" href="create.html">Create Room</a>
+      <a class="btn" href="join.html">Join Room</a>
+    </div>
   </div>
-
-  <script src="./client.js"></script>
 </body>
 </html>

--- a/public/join.html
+++ b/public/join.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Join Room - SyncIt</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body class="join">
+  <div class="center">
+    <h1>Join Room</h1>
+    <input id="code" maxlength="6" placeholder="Room Code" class="input" />
+    <button id="join" class="btn">Join</button>
+    <p id="err" class="error"></p>
+  </div>
+  <script>
+    document.getElementById('join').onclick = () => {
+      const code = document.getElementById('code').value.trim().toUpperCase();
+      if (!/^[A-Z0-9]{6}$/.test(code)) {
+        document.getElementById('err').textContent = 'Invalid code';
+        return;
+      }
+      location.href = `room.html?roomId=${code}`;
+    };
+  </script>
+</body>
+</html>

--- a/public/room.html
+++ b/public/room.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Room - SyncIt</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body class="room">
+  <header class="topbar">
+    <span id="roomLabel"></span>
+  </header>
+  <main class="layout">
+    <section class="playlist" id="playlist">
+      <div class="playlist-header">
+        <h2>Playlist</h2>
+        <div class="playlist-actions">
+          <label class="btn file-btn">
+            Add Files
+            <input id="fileInput" type="file" accept="audio/mpeg,audio/wav,audio/mp4,audio/ogg" multiple hidden />
+          </label>
+          <div class="toolbar">
+            <button id="loopQueue" title="Loop Queue" class="icon"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M17 17h4v4h-2v-2h-2zM7 7V5h8a4 4 0 0 1 4 4v3h-2V9a2 2 0 0 0-2-2H7v2L3 5l4-4v2h8a6 6 0 0 1 6 6v3a6 6 0 0 1-6 6H7v2l-4-4 4-4v2h8a4 4 0 0 0 4-4V7a4 4 0 0 0-4-4H7z"/></svg></button>
+            <button id="loopSong" title="Loop Song" class="icon"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M17 17h4v4h-2v-2h-2zM7 7V5h8a4 4 0 0 1 4 4v3h-2V9a2 2 0 0 0-2-2H7v2L3 5l4-4v2h8a6 6 0 0 1 6 6v3a6 6 0 0 1-6 6H7v2l-4-4 4-4v2h3V9h2v6h-5z"/></svg></button>
+            <button id="shuffle" title="Shuffle" class="icon"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M17 3h4v4h-2V5h-2l-3 5 3 5h2v-2h2v4h-4l-4-6 4-6zm-6 0L7 9l4 6h-4l-4-6 4-6z"/></svg></button>
+            <button id="reorderBtn" title="Reorder" class="icon"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M3 7h18v2H3V7zm0 4h18v2H3v-2zm0 4h18v2H3v-2z"/></svg></button>
+          </div>
+        </div>
+      </div>
+      <div id="fileError" class="error"></div>
+      <div id="playlistEmpty" class="empty">No tracks yet. Add files to start listening.</div>
+      <ul id="tracks" class="track-list"></ul>
+    </section>
+    <section class="controls" id="controls">
+      <audio id="audio" crossorigin="anonymous"></audio>
+      <div class="progress">
+        <input type="range" id="seek" min="0" max="100" value="0" />
+      </div>
+      <div class="buttons">
+        <button id="prev" class="icon" title="Previous"><svg viewBox="0 0 24 24" width="28" height="28" fill="currentColor"><path d="M6 12l8.5 6V6zM6 6h2v12H6z"/></svg></button>
+        <button id="play" class="icon" title="Play/Pause"><svg id="playIcon" viewBox="0 0 24 24" width="28" height="28" fill="currentColor"><path d="M8 5v14l11-7z"/></svg></button>
+        <button id="next" class="icon" title="Next"><svg viewBox="0 0 24 24" width="28" height="28" fill="currentColor"><path d="M18 12L9.5 6v12zM18 6h-2v12h2z"/></svg></button>
+        <input id="volume" type="range" min="0" max="1" step="0.01" />
+      </div>
+    </section>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/jsmediatags@3.9.5/dist/jsmediatags.min.js"></script>
+  <script src="./room.js"></script>
+</body>
+</html>

--- a/public/room.js
+++ b/public/room.js
@@ -1,0 +1,204 @@
+const qs = new URLSearchParams(location.search);
+const roomId = (qs.get('roomId') || '').toUpperCase();
+const host = qs.get('host') === '1';
+
+const ws = new WebSocket(`${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}`);
+let clientId = null;
+let isHost = host;
+let playlist = [];
+let current = -1;
+let flags = { loopQueue:false, loopSong:false, shuffle:false };
+
+// UI elements
+const roomLabel = document.getElementById('roomLabel');
+const fileInput = document.getElementById('fileInput');
+const tracksEl = document.getElementById('tracks');
+const emptyEl = document.getElementById('playlistEmpty');
+const audio = document.getElementById('audio');
+const seek = document.getElementById('seek');
+const playBtn = document.getElementById('play');
+const prevBtn = document.getElementById('prev');
+const nextBtn = document.getElementById('next');
+const vol = document.getElementById('volume');
+const playIcon = document.getElementById('playIcon');
+const loopQueueBtn = document.getElementById('loopQueue');
+const loopSongBtn = document.getElementById('loopSong');
+const shuffleBtn = document.getElementById('shuffle');
+const reorderBtn = document.getElementById('reorderBtn');
+const fileError = document.getElementById('fileError');
+
+roomLabel.textContent = roomId;
+
+// WebRTC pieces
+let stream = null;
+let pc = null; // listener
+const peers = new Map(); // host: peerId -> pc
+
+function $(sel){return document.querySelector(sel);} // util
+
+function renderPlaylist(){
+  tracksEl.innerHTML='';
+  if(playlist.length===0){ emptyEl.classList.remove('hidden'); return; }
+  emptyEl.classList.add('hidden');
+  playlist.forEach((t,i)=>{
+    const li=document.createElement('li');
+    li.className='track';
+    li.draggable=isHost && reorderBtn.classList.contains('active');
+    li.dataset.index=i;
+    if(i===current) li.classList.add('active');
+    li.innerHTML=`<span class="title">${i+1}. ${t.title}</span><span class="meta">${t.filename}</span>${isHost?'<button class="trash" title="Remove">🗑️</button>':''}`;
+    li.addEventListener('click',()=>{ if(isHost) playIndex(i); });
+    if(isHost){
+      li.querySelector('.trash').addEventListener('click',e=>{e.stopPropagation(); removeIndex(i);});
+      if(reorderBtn.classList.contains('active')){
+        li.addEventListener('dragstart',e=>{e.dataTransfer.setData('text/plain',i);});
+        li.addEventListener('dragover',e=>{e.preventDefault();});
+        li.addEventListener('drop',e=>{e.preventDefault(); const from=Number(e.dataTransfer.getData('text/plain')); const to=i; reorder(from,to);});
+      }
+    }
+    tracksEl.appendChild(li);
+  });
+}
+
+function sendPlaylist(){
+  if(isHost) ws.send(JSON.stringify({type:'playlist:update', playlist: playlist.map(t=>({title:t.title,filename:t.filename}))}));
+}
+
+function playIndex(i){
+  if(i<0||i>=playlist.length) return;
+  current=i;
+  audio.src=playlist[i].url;
+  audio.play();
+  renderPlaylist();
+  if(isHost) ws.send(JSON.stringify({type:'control:track', index:i}));
+  if(isHost) ws.send(JSON.stringify({type:'control:playpause', state:'play'}));
+}
+
+function removeIndex(i){
+  playlist.splice(i,1);
+  if(current===i){ current=-1; audio.pause(); }
+  if(current>i) current--; renderPlaylist(); sendPlaylist();
+}
+
+function reorder(from,to){
+  if(from===to) return; const item=playlist.splice(from,1)[0]; playlist.splice(to,0,item);
+  if(current===from) current=to; else if(current>from && current<=to) current--; else if(current<from && current>=to) current++;
+  renderPlaylist(); sendPlaylist();
+}
+
+function nextTrack(){
+  if(flags.shuffle){
+    let next; if(playlist.length<=1) next=current; else { do{ next=Math.floor(Math.random()*playlist.length); }while(next===current); }
+    current=next;
+  } else {
+    current++; if(current>=playlist.length){ if(flags.loopQueue) current=0; else { current=-1; audio.pause(); renderPlaylist(); return; }}
+  }
+  playIndex(current);
+}
+
+audio.addEventListener('ended',()=>{
+  if(flags.loopSong){ playIndex(current); } else { nextTrack(); }
+});
+
+audio.addEventListener('timeupdate',()=>{
+  if(audio.duration) seek.value = (audio.currentTime/audio.duration)*100;
+});
+audio.addEventListener('play',updatePlayIcon);
+audio.addEventListener('pause',updatePlayIcon);
+seek.addEventListener('input',()=>{
+  if(audio.duration) audio.currentTime = (seek.value/100)*audio.duration;
+  if(isHost) ws.send(JSON.stringify({type:'control:seek', time: audio.currentTime}));
+});
+
+playBtn.onclick=()=>{
+  if(audio.paused){ audio.play(); if(isHost) ws.send(JSON.stringify({type:'control:playpause', state:'play'})); }
+  else { audio.pause(); if(isHost) ws.send(JSON.stringify({type:'control:playpause', state:'pause'})); }
+};
+prevBtn.onclick=()=>{ if(current>0){ playIndex(current-1); } };
+nextBtn.onclick=()=>{ nextTrack(); };
+vol.addEventListener('input',()=>{ audio.volume=vol.value; if(isHost) ws.send(JSON.stringify({type:'control:volume', volume:vol.value})); });
+
+function updatePlayIcon(){
+  if(audio.paused){ playIcon.innerHTML='<path d="M8 5v14l11-7z"/>'; }
+  else { playIcon.innerHTML='<path d="M6 5h4v14H6zm8 0h4v14h-4z"/>'; }
+}
+
+function updateFlagButtons(){
+  loopQueueBtn.classList.toggle('active', flags.loopQueue);
+  loopSongBtn.classList.toggle('active', flags.loopSong);
+  shuffleBtn.classList.toggle('active', flags.shuffle);
+}
+
+loopQueueBtn.onclick=()=>{ if(!isHost) return; flags.loopQueue=!flags.loopQueue; if(flags.loopQueue) flags.loopSong=false; updateFlagButtons(); ws.send(JSON.stringify({type:'control:flags', flags})); };
+loopSongBtn.onclick=()=>{ if(!isHost) return; flags.loopSong=!flags.loopSong; if(flags.loopSong) flags.loopQueue=false; updateFlagButtons(); ws.send(JSON.stringify({type:'control:flags', flags})); };
+shuffleBtn.onclick=()=>{ if(!isHost) return; flags.shuffle=!flags.shuffle; updateFlagButtons(); ws.send(JSON.stringify({type:'control:flags', flags})); };
+reorderBtn.onclick=()=>{ if(!isHost) return; reorderBtn.classList.toggle('active'); renderPlaylist(); };
+
+fileInput.addEventListener('change', async (e)=>{
+  const files=[...e.target.files];
+  for(const file of files){
+    const ext=file.name.split('.').pop().toLowerCase();
+    if(!['mp3','wav','m4a','ogg'].includes(ext)){ fileError.textContent=`Unsupported type: ${file.name}`; setTimeout(()=>fileError.textContent='',3000); continue; }
+    const url=URL.createObjectURL(file);
+    let title=file.name.replace(/^.*\\/,'');
+    try{
+      await new Promise((res,rej)=>{
+        jsmediatags.read(file,{
+          onSuccess:tag=>{ if(tag.tags.title) title=tag.tags.title; res(); },
+          onError:()=>res()
+        });
+      });
+    }catch{}
+    // dedupe titles
+    const base=title; let n=2;
+    while(playlist.some(t=>t.title===title)){ title=`${base} (${n++})`; }
+    playlist.push({title, filename:file.name, url});
+  }
+  renderPlaylist(); sendPlaylist();
+});
+
+ws.onmessage=async ev=>{
+  const msg=JSON.parse(ev.data);
+  if(msg.type==='hello'){ clientId=msg.clientId; }
+  else if(msg.type==='error'){ alert(msg.message); }
+  else if(msg.type==='room:created'){ isHost=true; }
+  else if(msg.type==='room:joined'){ isHost=msg.host===true; if(!isHost){ fileInput.disabled=true; seek.disabled=true; playBtn.disabled=true; prevBtn.disabled=true; nextBtn.disabled=true; vol.disabled=true; } }
+  else if(msg.type==='webrtc:new-peer'){ if(isHost) hostCreateSenderFor(msg.peerId); }
+  else if(msg.type==='webrtc:signal'){ const {fromId,payload}=msg; if(payload.kind==='offer'){ await listenerHandleOffer(fromId,payload.sdp); } else if(payload.kind==='answer'){ const p=peers.get(fromId); if(p) await p.pc.setRemoteDescription(new RTCSessionDescription(payload.sdp)); } else if(payload.kind==='ice'){ if(isHost){ const p=peers.get(fromId); if(p) await p.pc.addIceCandidate(payload.candidate); } else { if(!pc) await ensureListenerPC(); await pc.addIceCandidate(payload.candidate); } }}
+  else if(msg.type==='control:playpause'){ if(!isHost && remote.srcObject) { if(msg.state==='play') remote.play().catch(()=>{}); if(msg.state==='pause') remote.pause(); }}
+  else if(msg.type==='control:seek'){ if(!isHost && remote.srcObject){ remote.pause(); setTimeout(()=>remote.play().catch(()=>{}),50); }}
+  else if(msg.type==='control:volume'){ if(!isHost && remote.srcObject && !remote.dataset.userVol){ remote.volume=Number(msg.volume); }}
+  else if(msg.type==='control:track'){ current=msg.index; renderPlaylist(); }
+  else if(msg.type==='control:flags'){ flags=msg.flags; updateFlagButtons(); }
+  else if(msg.type==='playlist:update'){ playlist=msg.playlist.map(t=>({title:t.title, filename:t.filename})); renderPlaylist(); }
+  else if(msg.type==='sync:state'){ playlist=msg.state.playlist; current=msg.state.current; flags=msg.state.flags; renderPlaylist(); updateFlagButtons(); if(!isHost){ remote.volume=msg.state.volume; if(msg.state.playing) remote.play().catch(()=>{}); } }
+  else if(msg.type==='sync:request' && isHost){ ws.send(JSON.stringify({type:'sync:state', targetId: msg.targetId, state:{playlist, current, flags, volume: audio.volume, playing: !audio.paused}})); }
+};
+
+ws.onopen=()=>{
+  if(host) ws.send(JSON.stringify({type:'room:create', roomId}));
+  else ws.send(JSON.stringify({type:'room:join', roomId}));
+};
+
+// --- WebRTC helpers copied/simplified from previous client ---
+async function ensureHostStream(){
+  if(stream) return stream; if(!audio.captureStream) throw new Error('captureStream unsupported'); stream=audio.captureStream(); return stream;
+}
+async function hostCreateSenderFor(peerId){
+  await ensureHostStream();
+  const pcHost=new RTCPeerConnection({iceServers:[{urls:['stun:stun.l.google.com:19302']}]});
+  stream.getAudioTracks().forEach(tr=>pcHost.addTrack(tr,stream));
+  pcHost.onicecandidate=e=>{ if(e.candidate){ ws.send(JSON.stringify({type:'webrtc:signal', targetId:peerId, payload:{kind:'ice', candidate:e.candidate}})); } };
+  peers.set(peerId,{pc:pcHost});
+  const offer=await pcHost.createOffer({offerToReceiveAudio:false});
+  await pcHost.setLocalDescription(offer);
+  ws.send(JSON.stringify({type:'webrtc:signal', targetId:peerId, payload:{kind:'offer', sdp:offer}}));
+}
+async function ensureListenerPC(){ if(pc) return pc; pc=new RTCPeerConnection({iceServers:[{urls:['stun:stun.l.google.com:19302']}]}); pc.ontrack=e=>{ remote.srcObject=e.streams[0]; }; return pc; }
+async function listenerHandleOffer(fromId,sdp){ await ensureListenerPC(); await pc.setRemoteDescription(new RTCSessionDescription(sdp)); const ans=await pc.createAnswer(); await pc.setLocalDescription(ans); ws.send(JSON.stringify({type:'webrtc:signal', targetId:fromId, payload:{kind:'answer', sdp:ans}})); }
+const remote=document.createElement('audio');
+remote.autoplay=true;
+remote.id='remote';
+document.body.appendChild(remote);
+remote.addEventListener('volumechange',()=>{remote.dataset.userVol='1';});
+updateFlagButtons();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,12 +1,158 @@
-body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; background: #0b1020; color: #eaeef7; }
-.container { max-width: 900px; margin: 2rem auto; padding: 1rem; }
-h1, h2 { margin: 0 0 0.75rem 0; }
-section { background: #111834; border: 1px solid #1b2448; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; box-shadow: 0 4px 16px rgba(0,0,0,0.25); }
-.row { display: flex; gap: 0.5rem; align-items: center; margin: 0.5rem 0; flex-wrap: wrap; }
-input, select, button { padding: 0.5rem 0.75rem; border-radius: 8px; border: 1px solid #2b366d; background: #0e1440; color: #eaeef7; }
-button { cursor: pointer; background: #23307a; border-color: #23307a; }
-button:hover { background: #2b3990; }
-.hidden { display: none; }
-.chat-box { height: 180px; overflow: auto; background: #0e1440; border: 1px solid #2b366d; padding: 0.5rem; border-radius: 8px; }
-.chat-line { margin: 0.25rem 0; }
-#remoteAudio, #audio { width: 100%; }
+:root {
+  --bg: #1b1b1b;
+  --card: #242424;
+  --text: #eeeeee;
+  --accent: #F92A53;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
+}
+
+.center {
+  max-width: 480px;
+  margin: 10vh auto;
+  text-align: center;
+  padding: 1rem;
+}
+
+h1 {
+  margin-top: 0;
+}
+
+.btn {
+  background: var(--accent);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  margin: 0.25rem;
+}
+.btn:hover,
+.btn:focus {
+  opacity: 0.9;
+}
+
+.input {
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid #444;
+  background: #1e1e1e;
+  color: var(--text);
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.error { color: #f66; font-size: 0.9rem; }
+
+.room-code {
+  font-size: 2rem;
+  letter-spacing: 0.1em;
+  margin: 1rem 0;
+}
+
+.topbar {
+  background: #222;
+  padding: 0.5rem 1rem;
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.playlist, .controls {
+  background: var(--card);
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+}
+
+.playlist-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.file-btn {
+  position: relative;
+  overflow: hidden;
+}
+.file-btn input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.toolbar .icon {
+  background: none;
+  border: none;
+  width: 32px;
+  height: 32px;
+  margin-left: 0.25rem;
+  cursor: pointer;
+}
+.icon { color: #ccc; }
+.icon:hover, .icon:focus { color: var(--accent); }
+.icon.active { color: var(--accent); }
+
+.track-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.track {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid #333;
+  cursor: pointer;
+}
+.track:last-child { border-bottom: none; }
+.track.active { color: var(--accent); }
+.track .title { flex: 1; }
+.track .meta { font-size: 0.8rem; color: #888; }
+.track .trash {
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+}
+.track .trash:hover { color: #fff; }
+
+.empty {
+  text-align: center;
+  color: #888;
+  padding: 1rem 0;
+}
+
+.controls .progress {
+  margin-bottom: 0.5rem;
+}
+.controls .buttons {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.controls .icon {
+  background: none;
+  border: none;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}
+
+.controls input[type="range"] {
+  flex: 1;
+}

--- a/server.js
+++ b/server.js
@@ -113,6 +113,7 @@ wss.on("connection", (ws) => {
       // Ask host to create a WebRTC sender for this new peer
       if (room.hostId && room.hostId !== clientId) {
         safeSend(room.sockets.get(room.hostId), { type: "webrtc:new-peer", peerId: clientId });
+        safeSend(room.sockets.get(room.hostId), { type: "sync:request", targetId: clientId });
       }
     }
 
@@ -153,6 +154,44 @@ wss.on("connection", (ws) => {
       const room = rooms.get(roomId);
       if (room?.hostId !== clientId) return;
       broadcast(roomId, { type: "control:mute", muted: data.muted }, clientId);
+    }
+
+    else if (data.type === "control:track") {
+      const roomId = inRoom.get(clientId);
+      const room = rooms.get(roomId);
+      if (room?.hostId !== clientId) return;
+      broadcast(roomId, { type: "control:track", index: data.index }, clientId);
+    }
+
+    else if (data.type === "control:flags") {
+      const roomId = inRoom.get(clientId);
+      const room = rooms.get(roomId);
+      if (room?.hostId !== clientId) return;
+      broadcast(roomId, { type: "control:flags", flags: data.flags }, clientId);
+    }
+
+    else if (data.type === "playlist:update") {
+      const roomId = inRoom.get(clientId);
+      const room = rooms.get(roomId);
+      if (room?.hostId !== clientId) return;
+      broadcast(roomId, { type: "playlist:update", playlist: data.playlist }, clientId);
+    }
+
+    else if (data.type === "sync:request") {
+      const roomId = inRoom.get(clientId);
+      const room = rooms.get(roomId);
+      if (!room) return;
+      if (room.hostId && room.hostId !== clientId) {
+        safeSend(room.sockets.get(room.hostId), { type: "sync:request", targetId: clientId });
+      }
+    }
+
+    else if (data.type === "sync:state") {
+      const roomId = inRoom.get(clientId);
+      const room = rooms.get(roomId);
+      if (room?.hostId !== clientId) return;
+      const target = room.sockets.get(data.targetId);
+      if (target) safeSend(target, { type: "sync:state", state: data.state });
     }
 
     else if (data.type === "host:transfer") {


### PR DESCRIPTION
## Summary
- Replace single-page app with landing, create, join, and room pages
- Implement playlist panel with drag-and-drop, loop/shuffle controls, and synced playback state
- Extend server to broadcast playlist updates, track selections, and sync state to late joiners

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68984cce170c8331b681bb07beabdede